### PR TITLE
コンポーネントの不要な再レンダリングを修正し、パフォーマンスを向上

### DIFF
--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -22,7 +22,7 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="testing_sqlite"/>
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/src/resources/ts/pages/components/MedicineCheckboxGroup.tsx
+++ b/src/resources/ts/pages/components/MedicineCheckboxGroup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { MedicineCheckboxItem } from "./MedicineCheckboxItem";
 
 interface MedicineCheckboxGroupProps {
@@ -10,28 +10,29 @@ interface MedicineCheckboxGroupProps {
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const MedicineCheckboxGroup: React.FC<MedicineCheckboxGroupProps> = (props) => {
-const { items, name, labelText, formDataItem, error, onChange } = props;
-return (
-    <div className="d_container flexiblebox">
-        <dt className="dt regist_dt_bg">{labelText}</dt>
-        <dd className="dd">
-            <div className="check_layout">
-            {items.map((item) => (
-                <React.Fragment key={item.id}>
-                    <MedicineCheckboxItem 
-                        id={item.id}
-                        name={name}
-                        labelText={item.day_name}
-                        value={item.id}
-                        checked={formDataItem.includes(item.id)}
-                        onChange={onChange}
-                    />
-                </React.Fragment>
-            ))}
-            </div>
-            {error && <p className="error">{error}</p>}
-        </dd>
-    </div>
+export const MedicineCheckboxGroup: React.FC<MedicineCheckboxGroupProps> = memo((props) => {
+    console.log('MedicineCheckboxGroup')
+    const { items, name, labelText, formDataItem, error, onChange } = props;
+    return (
+        <div className="d_container flexiblebox">
+            <dt className="dt regist_dt_bg">{labelText}</dt>
+            <dd className="dd">
+                <div className="check_layout">
+                {items.map((item) => (
+                    <React.Fragment key={item.id}>
+                        <MedicineCheckboxItem 
+                            id={item.id}
+                            name={name}
+                            labelText={item.day_name}
+                            value={item.id}
+                            checked={formDataItem.includes(item.id)}
+                            onChange={onChange}
+                        />
+                    </React.Fragment>
+                ))}
+                </div>
+                {error && <p className="error">{error}</p>}
+            </dd>
+        </div>
     );
-};
+});

--- a/src/resources/ts/pages/components/MedicineCheckboxItem.tsx
+++ b/src/resources/ts/pages/components/MedicineCheckboxItem.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 
 interface MedicineCheckboxItemProps {
     id: number;
@@ -9,8 +9,9 @@ interface MedicineCheckboxItemProps {
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const MedicineCheckboxItem: React.FC<MedicineCheckboxItemProps> = (props) => {
+export const MedicineCheckboxItem: React.FC<MedicineCheckboxItemProps> = memo((props) => {
   const { id, name, labelText, value, checked, onChange } = props;
+  console.log('MedicineCheckboxItem')
   return (
     <>
         <input
@@ -24,4 +25,4 @@ export const MedicineCheckboxItem: React.FC<MedicineCheckboxItemProps> = (props)
         <label htmlFor={`${name}${id}`}>{labelText}</label>
     </>
   );
-};
+});

--- a/src/resources/ts/pages/components/MedicineDoseAmount.tsx
+++ b/src/resources/ts/pages/components/MedicineDoseAmount.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { Unit } from "../../types/Unit";
 
 interface MedicineDoseAmountProps {
@@ -11,8 +11,9 @@ interface MedicineDoseAmountProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
 }
 
-export const MedicineDoseAmount: React.FC<MedicineDoseAmountProps> = (props) => {
+export const MedicineDoseAmount: React.FC<MedicineDoseAmountProps> = memo((props) => {
   const { labelText, doseAmount, units, errorDose, errorUnit, onChange } = props;
+  console.log('MedicineDoseAmount')
   return (
       <div className="d_container flexiblebox">
           <dt className="dt regist_dt_bg"><label htmlFor="dose_amount">{labelText}</label></dt>
@@ -30,4 +31,4 @@ export const MedicineDoseAmount: React.FC<MedicineDoseAmountProps> = (props) => 
           </dd>
       </div>
   );
-};
+});

--- a/src/resources/ts/pages/components/MedicineFormButton.tsx
+++ b/src/resources/ts/pages/components/MedicineFormButton.tsx
@@ -1,12 +1,13 @@
-import React from "react";
+import React, { memo } from "react";
 
 interface MedicineFormButtonProps {
   buttonText: string;
 }
 
-export const MedicineFormButton: React.FC<MedicineFormButtonProps> = (props) => {
+export const MedicineFormButton: React.FC<MedicineFormButtonProps> = memo((props) => {
+  console.log('MedicineFormButton')
   const { buttonText } = props;
   return (
       <p className="btn_center"><input type="submit" className="submit regist_sub_design regist_submit_color" value={buttonText} /></p>
   );
-};
+});

--- a/src/resources/ts/pages/components/MedicineInput.tsx
+++ b/src/resources/ts/pages/components/MedicineInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 
 interface MedicineInputProps {
   labelText: string;
@@ -10,7 +10,7 @@ interface MedicineInputProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const MedicineInput: React.FC<MedicineInputProps> = (props) => {
+export const MedicineInput: React.FC<MedicineInputProps> = memo((props) => {
   const {labelText, name, id, type, value, error, onChange} = props;
   console.log('MedicineInput');
   return (
@@ -29,4 +29,4 @@ export const MedicineInput: React.FC<MedicineInputProps> = (props) => {
       </dd>
     </div>
   );
-};
+});

--- a/src/resources/ts/pages/header/index.tsx
+++ b/src/resources/ts/pages/header/index.tsx
@@ -9,7 +9,7 @@ const MedicineHeader = () => {
           <div className="header_container header_flex">
               <div className="header_inner container">
                   <p>
-                      <a href="/" className="top_title">服用チェック</a>
+                      <Link to="/" className="top_title">服用チェック</Link>
                   </p>
                   <button className="btn_hamburger">
                       <span className="hamburger_logo"></span>

--- a/src/resources/ts/pages/medicines/create.tsx
+++ b/src/resources/ts/pages/medicines/create.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, ChangeEvent} from 'react';
+import React, {useEffect, useState, useCallback, useMemo, ChangeEvent} from 'react';
 import dayjs from 'dayjs';
 import { Medicine } from '../../types/Medicine';
 import { DayOfWeek } from '../../types/DayOfWeek';
@@ -57,15 +57,21 @@ const MedicineCreatePage = () => {
     }
   }, [error]);
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
-    setFormData({
-      ...formData,
-      [name]: value
+  const timeItems = useMemo(() => {
+    return Array.from({ length: 24 }, (_, i) => {
+      return { id: i, day_name: `${i}:00` };
     });
-  };
+  }, []); // 依存配列を空にし、コンポーネントのマウント時に一度だけ作成する 
+
+  const handleChange = useCallback((e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData(prevFormData => ({
+      ...prevFormData,
+      [name]: value
+    }));
+    }, []);// 関数内で直接 formData の状態を参照せず、setFormData で関数を使用しているため、依存配列は空にする
   
-  const handleCheckboxChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleCheckboxChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);
     const name = e.target.name;  // チェックボックスの name 属性を取得
   
@@ -78,7 +84,7 @@ const MedicineCreatePage = () => {
         return { ...prevState, [name]: existingValues.filter(item => item !== value) };
       }
     });
-  };
+  }, []);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -114,10 +120,7 @@ const MedicineCreatePage = () => {
         <MedicineCheckboxGroup
           labelText="服用時刻"
           name="times"
-          // items={daysOfWeek}
-          items={Array.from({ length: 24 }, (_, i) => {
-            return { id: i, day_name: `${i}:00` };
-          })}
+          items={timeItems}
           formDataItem={formData.times}
           error={errors.times}
           onChange={handleCheckboxChange}


### PR DESCRIPTION
- 不要な再レンダリングを防ぐために、子コンポーネントにmemoを適用。
- 子コンポーネントのpropsに渡す関数が、各レンダリングごとに異なる参照を生成する問題を解消するため、useCallbackで関数をラップし、memo化されたコンポーネントのpropsとして渡す。
- 親コンポーネントから渡される MedicineDoseAmount.tsxの items props が、親コンポーネントのレンダリングのたびに新しい配列が生成されてしまう問題を解消するため、useMemoを適用し、コンポーネントがマウントされた時のみ配列が生成されるように修正。